### PR TITLE
Патерн "Ітератор"

### DIFF
--- a/Lab3/Composite/ClassLibrary/BreadthIterator.cs
+++ b/Lab3/Composite/ClassLibrary/BreadthIterator.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using System.Text;
+
+namespace ClassLibrary
+{
+    public class BreadthIterator : IIterator
+    {
+        private Queue<LightNode> queue;
+
+        public BreadthIterator(LightNode node)
+        {
+            queue = new Queue<LightNode>();
+            queue.Enqueue(node);
+        }
+
+        public bool HasNext()
+        {
+            return queue.Count > 0;
+        }
+
+        public LightNode Next()
+        {
+            if (!HasNext())
+            {
+                Console.WriteLine("No more elements");
+            }
+
+            LightNode node = queue.Dequeue();
+            if (node is LightElementNode elementNode)
+            {
+                foreach (LightNode lightNode in elementNode.Children)
+                {
+                    {
+                        queue.Enqueue(lightNode);
+
+                    }
+                }
+            }
+            return node;
+        }
+    }
+}

--- a/Lab3/Composite/ClassLibrary/DepthIterator.cs
+++ b/Lab3/Composite/ClassLibrary/DepthIterator.cs
@@ -1,0 +1,38 @@
+﻿using System.Text;
+
+namespace ClassLibrary
+{
+    public class DepthIterator : IIterator
+    {
+        private Stack<LightNode> stack;
+
+        public DepthIterator(LightNode node)
+        {
+            stack = new Stack<LightNode>();
+            stack.Push(node);
+        }
+
+        public bool HasNext()
+        {
+            return stack.Count > 0;
+        }
+
+        public LightNode Next()
+        {
+            if (!HasNext())
+            {
+                Console.WriteLine("No more elements");
+            }
+
+            LightNode node = stack.Pop();
+            if (node is LightElementNode elementNode)
+            {
+                for (int i = elementNode.Children.Count - 1; i >= 0; i--)
+                {
+                    stack.Push(elementNode.Children[i]);
+                }
+            }
+            return node;
+        }
+    }
+}

--- a/Lab3/Composite/ClassLibrary/IIterator.cs
+++ b/Lab3/Composite/ClassLibrary/IIterator.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ClassLibrary
+{
+    public interface IIterator
+    {
+        bool HasNext();
+        LightNode Next();
+    }
+}

--- a/Lab3/Composite/Composite/Program.cs
+++ b/Lab3/Composite/Composite/Program.cs
@@ -3,6 +3,7 @@ public class Program
 {
     public static void Main()
     {
+        Console.OutputEncoding = System.Text.Encoding.UTF8;
         var div = new LightElementNode("div", DisplayType.Block, TagType.Pair);
         div.AddClass("container");
 
@@ -16,7 +17,19 @@ public class Program
         div.AddChild(h1);
         div.AddChild(p);
 
-        Console.WriteLine();
-        Console.WriteLine(div.OuterHTML);
+        Console.WriteLine("Ітератор для обоходу в глибину");
+        IIterator iterator = new DepthIterator(div);
+        while (iterator.HasNext())
+        {
+            LightNode node = iterator.Next();
+            Console.WriteLine(node.OuterHTML);
+        }
+        Console.WriteLine("\nІтератор для обоходу в ширину");
+        IIterator iterator1 = new BreadthIterator(div);
+        while (iterator1.HasNext())
+        {
+            LightNode node = iterator1.Next();
+            Console.WriteLine(node.OuterHTML);
+        }
     }
 }


### PR DESCRIPTION
Реалізовано поведінковий патерн "Ітератор", який дозволяє поетапно перебирати HTML-елементи без розкриття їхньої внутрішньої структури.

Зміни:
- Реалізовано інтерфейс `IIterator` для перебору елементів.
- Додано `DepthIterator` — ітератор для обходу HTML-дерева в глибину.
- Додано `BreadthIterator` — ітератор для обходу в ширину.

Це дозволяє зручно та структуровано перебирати вузли HTML-документу, не заглиблюючись у рекурсію.